### PR TITLE
Open GuiChat when command prefix is typed

### DIFF
--- a/src/main/java/net/daporkchop/pepsimod/mixin/client/MixinMinecraft.java
+++ b/src/main/java/net/daporkchop/pepsimod/mixin/client/MixinMinecraft.java
@@ -27,11 +27,13 @@ import net.daporkchop.pepsimod.util.config.impl.FriendsTranslator;
 import net.daporkchop.pepsimod.util.misc.ITickListener;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fml.common.FMLLog;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
 import org.spongepowered.asm.mixin.Mixin;
@@ -159,6 +161,15 @@ public abstract class MixinMinecraft {
             }
         } catch (NullPointerException e) {
 
+        }
+    }
+
+    @Inject(method = "processKeyBinds", at = @At("HEAD"))
+    public void preProcessKeyBinds(CallbackInfo ci) {
+        // If . is typed open GuiChat
+        // Bypass the keybind system because the command prefix is not configurable
+        if (mc.currentScreen == null && Keyboard.getEventCharacter() == '.') {
+            mc.displayGuiScreen(new GuiChat("."));
         }
     }
 }


### PR DESCRIPTION
Just like typing `/`, typing `.` should open the chat to allow quickly typing commands.

I have deliberately not used the forge keybind system because the command prefix is not currently configurable. I also don't check the key pressed because different keyboard layouts may not type a `.` on key `0x34`.

Instead I check the typed char, just before Minecraft checks its own keybinds in `net.minecraft.client.Minecraft.processKeyBinds()`.